### PR TITLE
fix: Git clone link

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -23,7 +23,7 @@ To get started with contributing to Chaty, follow these steps:
 2. Clone your forked repository to your local machine:
 
    ```bash
-   git clone https://github.com/your-username/chaty.git
+   git clone https://github.com/JaeAeich/Chaty.git
    ```
 
 3. Create a new branch for your contribution:


### PR DESCRIPTION
Wrong git link fix, this could make it hard for new users to contribute.